### PR TITLE
Fix typo in link to Ubuntu docs.

### DIFF
--- a/en/_posts/2016-04-29-mroonga-6.02.md
+++ b/en/_posts/2016-04-29-mroonga-6.02.md
@@ -40,7 +40,7 @@ From this release, we start to provide Mroonga package for Ubuntu 16.04 (Xenial 
 
 For more information about how to install, please refer to the following document:
 
-  * [How to install on Ubuntu 16.04 (Xenial Xerus)](http://mroonga.org/en/docs/install/ubuntu.html)
+  * [How to install on Ubuntu 16.04 (Xenial Xerus)](http://mroonga.org/docs/install/ubuntu.html)
 
 #### Fix compilation error with MySQL 5.7
 


### PR DESCRIPTION
Link didn't work. Now it does :)